### PR TITLE
Check cache for useCacheAsFailover

### DIFF
--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -489,7 +489,10 @@ class Flagsmith
                 $response = $this->call($method, $uri, $body);
                 $this->cache->set($cacheKey, $response);
             } catch (APIException $e) {
-                if (!$this->useCacheAsFailover) {
+                if (
+                    !$this->useCacheAsFailover ||
+                    !$this->cache->has($cacheKey)
+                   ) {
                     throw $e;
                 }
             }


### PR DESCRIPTION
Make sure cache key exists first when useCacheAsFailover is enabled before returning the cache