### PR TITLE
Remove Guzzle from require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "php": ">=7.4",
         "php-http/discovery": "^1.14",
         "psr/simple-cache": "^1.0",
-        "guzzlehttp/guzzle": "^7.3",
         "psr/http-factory-implementation": "1.0",
         "psr/http-client-implementation": "1.0",
         "psr/http-message-implementation": "1.0"


### PR DESCRIPTION
The entire point of having PSR implementations means that the end user is able to freely choose their own PSR implementation of the http libraries. Thus you shouldn't forcefully require Guzzle on end users (this can cause conflicts later in the lifespan of this library).

If anything you can coerce the user to install Guzzle but really they just need to install any library that is PSR compatible. 

This is a partial regression from #11