### PR TITLE
Solve php 8.2 deprecation

### DIFF
--- a/src/Engine/Utils/Collections/CollectionTrait.php
+++ b/src/Engine/Utils/Collections/CollectionTrait.php
@@ -23,6 +23,7 @@ trait CollectionTrait
      * Returns the object to JSON serialize.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getArrayCopy();

--- a/src/Engine/Utils/Collections/MultivariateFeatureStateValueModelList.php
+++ b/src/Engine/Utils/Collections/MultivariateFeatureStateValueModelList.php
@@ -14,6 +14,7 @@ class MultivariateFeatureStateValueModelList extends \ArrayObject implements \Js
      * Returns the object to JSON serialize.
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $stateValues = $this->getArrayCopy();


### PR DESCRIPTION
Hi @dabeeeenster @matthewelwell 

This PR solve 
```
Deprecated: Return type of Flagsmith\Utils\Collections\FlagModelsList::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```
in a BC way