### PR TITLE
PSR/simple-cache upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,5 @@
             "Flagsmith\\": "src",
             "FlagsmithTest\\": "tests"
         }
-    },
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.4",
         "php-http/discovery": "^1.14",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": ">=1.0",
         "psr/http-factory-implementation": "1.0",
         "psr/http-client-implementation": "1.0",
         "psr/http-message-implementation": "1.0"
@@ -29,6 +29,11 @@
         "psr-4": {
             "Flagsmith\\": "src",
             "FlagsmithTest\\": "tests"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
         }
     }
 }


### PR DESCRIPTION
This way we are able to install the library in projects where `psr/simple-cache` implementation is newer than version 1.x.