### PR TITLE
Add @throws annotation

### DIFF
--- a/src/Exceptions/APIException.php
+++ b/src/Exceptions/APIException.php
@@ -4,6 +4,9 @@ namespace Flagsmith\Exceptions;
 
 use Exception;
 
+/**
+ * @deprecated
+ */
 class APIException extends Exception
 {
 }

--- a/src/Exceptions/FlagsmithAPIError.php
+++ b/src/Exceptions/FlagsmithAPIError.php
@@ -4,6 +4,6 @@ namespace Flagsmith\Exceptions;
 
 use Exception;
 
-class FlagsmithAPIError extends Exception
+class FlagsmithAPIError extends Exception implements FlagsmithThrowable
 {
 }

--- a/src/Exceptions/FlagsmithClientError.php
+++ b/src/Exceptions/FlagsmithClientError.php
@@ -4,6 +4,6 @@ namespace Flagsmith\Exceptions;
 
 use Exception;
 
-class FlagsmithClientError extends Exception
+class FlagsmithClientError extends Exception implements FlagsmithThrowable
 {
 }

--- a/src/Exceptions/FlagsmithThrowable.php
+++ b/src/Exceptions/FlagsmithThrowable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Flagsmith\Exceptions;
+
+use Throwable;
+
+interface FlagsmithThrowable extends Throwable
+{
+}

--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -13,6 +13,7 @@ use Flagsmith\Engine\Utils\Collections\IdentityTraitList;
 use Flagsmith\Exceptions\APIException;
 use Flagsmith\Exceptions\FlagsmithAPIError;
 use Flagsmith\Exceptions\FlagsmithClientError;
+use Flagsmith\Exceptions\FlagsmithThrowable;
 use Flagsmith\Models\Flags;
 use Flagsmith\Models\Segment;
 use Flagsmith\Utils\AnalyticsProcessor;
@@ -52,6 +53,9 @@ class Flagsmith
     private array $headers = [];
     private ?EnvironmentModel $environment = null;
 
+    /**
+     * @throws ValueError
+     */
     public function __construct(
         string $apiKey,
         string $host = self::DEFAULT_API_URL,
@@ -262,6 +266,8 @@ class Flagsmith
     /**
      * Get all the default for flags for the current environment.
      * @return Flags
+     *
+     * @throws FlagsmithThrowable
      */
     public function getEnvironmentFlags(): Flags
     {
@@ -279,6 +285,8 @@ class Flagsmith
      * @param string $identifier
      * @param object|null $traits
      * @return Flags
+     *
+     * @throws FlagsmithThrowable
      */
     public function getIdentityFlags(string $identifier, ?object $traits = null): Flags
     {
@@ -297,6 +305,8 @@ class Flagsmith
      * @param object|null $traits a dictionary of traits to add / update on the identity in
      *      Flagsmith, e.g. {"num_orders": 10}
      * @return array
+     *
+     * @throws FlagsmithThrowable
      */
     public function getIdentitySegments(string $identifier, ?object $traits = null): array
     {
@@ -316,6 +326,8 @@ class Flagsmith
     /**
      * Externalised method to update the environement cache.
      * @return void
+     *
+     * @throws FlagsmithThrowable
      */
     public function updateEnvironment()
     {
@@ -327,6 +339,8 @@ class Flagsmith
     /**
      * Get the environment API.
      * @return EnvironmentModel
+     *
+     * @throws FlagsmithAPIError
      */
     private function getEnvironmentFromApi(): EnvironmentModel
     {
@@ -353,6 +367,8 @@ class Flagsmith
      * @param string $identifier
      * @param object $traits
      * @return Flags
+     *
+     * @throws FlagsmithClientError
      */
     private function getIdentityFlagsFromDocument(string $identifier, object $traits): Flags
     {
@@ -370,6 +386,8 @@ class Flagsmith
     /**
      * Get environment flags from API.
      * @return Flags
+     *
+     * @throws FlagsmithAPIError
      */
     private function getEnvironmentFlagsFromApi(): Flags
     {
@@ -393,6 +411,8 @@ class Flagsmith
      * Get the identity flags from API.
      *
      * @return Flags
+     *
+     * @throws FlagsmithAPIError
      */
     private function getIdentityFlagsFromApi(string $identifier, ?object $traits): Flags
     {
@@ -425,6 +445,8 @@ class Flagsmith
      * @param string $identifier
      * @param array|null $traits
      * @return IdentityModel
+     *
+     * @throws FlagsmithClientError
      */
     private function buildIdentityModel(string $identifier, ?object $traits): IdentityModel
     {
@@ -454,6 +476,8 @@ class Flagsmith
      * @param array $body
      * @param boolean $skipCache
      * @return object|array
+     *
+     * @throws FlagsmithAPIError
      */
     private function cachedCall(
         string $cacheKey,
@@ -472,7 +496,7 @@ class Flagsmith
             try {
                 $response = $this->call($method, $uri, $body);
                 $this->cache->set($cacheKey, $response, $ttl);
-            } catch (APIException $e) {
+            } catch (FlagsmithAPIError $e) {
                 if (
                     !$this->useCacheAsFailover ||
                     !$this->cache->has($cacheKey)
@@ -496,6 +520,8 @@ class Flagsmith
      * @param string $uri
      * @param array $body
      * @return object|array
+     *
+     * @throws FlagsmithAPIError
      */
     private function call(string $method, string $uri, array $body = [])
     {


### PR DESCRIPTION
Hi @matthewelwell,

IDE like PHPstorm or tools like PHPStan are helping developer to correctly try/catch exceptions when they are described in the phpdoc. Lot of them were missing in the Flagsmith so I tried to add them:
- I added `@throws FlagsmithClientError` or `@throws FlagsmithAPIError` to the private methods
- I created a `FlagsmithThrowable` interface to allow developer to catch every Flagsmith throwable without listing them
- I used `@throws FlagsmithThrowable` to the public method to let more flexibility in thrown exception
- I found no usage of `APIException` so I deprecated it
- There was one catch of APIException, but the exception thrown were FlagsmithAPIError so I fixed the try catch.