### PR TITLE
Use django id if present for percentage split evaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 composer.lock
 /node_modules/
 .env
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,7 +15,7 @@ return $config
         [
             '@PSR12' => true,
             'single_quote' => true,
-            'no_trailing_comma_in_singleline_array' => true,
+            'no_trailing_comma_in_singleline' => true,
             'array_indentation' => true,
             'phpdoc_indent' => true,
         ]

--- a/src/Engine/Identities/IdentityModel.php
+++ b/src/Engine/Identities/IdentityModel.php
@@ -19,7 +19,7 @@ class IdentityModel
     public IdentityFeaturesList $identity_features;
     public IdentityTraitList $identity_traits;
     public string $identity_uuid;
-    public int $djangoId;
+    public ?int $django_id = null;
 
     protected array $keys = [
         'identity_features' => 'Flagsmith\Engine\Utils\Collections\IdentityFeaturesList',
@@ -76,19 +76,19 @@ class IdentityModel
      * Get the django ID.
      * @return int
      */
-    public function getDjangoId(): int
+    public function getDjangoId(): ?int
     {
         return $this->django_id;
     }
 
     /**
      * Build with Django ID.
-     * @param int $djangoId
+     * @param int $django_id
      * @return IdentityModel
      */
-    public function withDjangoId(int $djangoId): self
+    public function withDjangoId(int $django_id): self
     {
-        return $this->with('django_id', $djangoId);
+        return $this->with('django_id', $django_id);
     }
 
     /**

--- a/src/Engine/Segments/SegmentEvaluator.php
+++ b/src/Engine/Segments/SegmentEvaluator.php
@@ -45,6 +45,7 @@ class SegmentEvaluator
         array $overrideTraits = null
     ): bool {
         $rulesCount = count($segment->getRules());
+        $identityId = ($identity->getDjangoId() != null) ? $identity->getDjangoId() : $identity->compositeKey();
 
         if (empty($rulesCount)) {
             return false;
@@ -55,7 +56,7 @@ class SegmentEvaluator
                 $overrideTraits ?? $identity->getIdentityTraits()->getArrayCopy(),
                 $rule,
                 $segment->getId(),
-                $identity->compositeKey()
+                $identityId
             );
 
             if (!$matchesRule) {

--- a/tests/Engine/Unit/Segments/SegmentEvaluatorTest.php
+++ b/tests/Engine/Unit/Segments/SegmentEvaluatorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Flagsmith\Engine\Utils\Collections\SegmentConditionModelList;
 use Flagsmith\Engine\Utils\Collections\SegmentRuleModelList;
 use Flagsmith\Engine\Utils\Hashing;
+use Flagsmith\Models\Segment;
 use FlagsmithTest\Engine\Fixtures;
 
 class SegmentEvaluatorTest extends TestCase
@@ -188,7 +189,6 @@ class SegmentEvaluatorTest extends TestCase
      */
     public function testIdentityInSegmentPercentageSplit($segmentSplitValue, $identityHashedPercentage, $expectedResult)
     {
-        $this->assertTrue(true);
         $percentageSplitCondition = (new SegmentConditionModel())
             ->withOperator(SegmentConditions::PERCENTAGE_SPLIT)
             ->withValue("{$segmentSplitValue}");
@@ -215,5 +215,47 @@ class SegmentEvaluatorTest extends TestCase
         $result = SegmentEvaluator::evaluateIdentityInSegment(Fixtures::identity(), $segmentModel);
 
         $this->assertEquals($result, $expectedResult);
+    }
+
+    public function testIdentityInSegmentPercentageSplitUsesDjangoIdIfPresent()
+    {
+        $percentageSplitCondition = (new SegmentConditionModel())
+            ->withOperator(SegmentConditions::PERCENTAGE_SPLIT)
+            ->withValue("10");
+
+        $segmentRule = (new SegmentRuleModel())
+            ->withType(SegmentRules::ALL_RULE)
+            ->withConditions(
+                new SegmentConditionModelList([$percentageSplitCondition])
+            );
+
+        $segmentModel = (new SegmentModel())
+            ->withId(1)
+            ->withName('splitty')
+            ->withRules(
+                new SegmentRuleModelList([$segmentRule])
+            );
+
+        $identityModel = (new IdentityModel())
+                ->withIdentifier('identifier_1')
+                ->withEnvironmentApiKey(Fixtures::environment()->getApiKey())
+                ->withCreatedDate(new \DateTime('now'))
+                ->withDjangoId(1);
+
+        $hashingStub = $this->createMock(Hashing::class);
+        $hashingStub
+            ->method('getHashedPercentageForObjectIds')
+            ->will($this->returnValue(1));
+
+        $hashingStub
+            ->expects($this->once())
+            ->method('getHashedPercentageForObjectIds')
+            ->with($this->identicalTo(array($segmentModel->getId(), $identityModel->getDjangoId())));
+
+        SegmentEvaluator::setHashObject($hashingStub);
+
+        $result = SegmentEvaluator::evaluateIdentityInSegment($identityModel, $segmentModel);
+
+        $this->assertEquals($result, True);
     }
 }

--- a/tests/Engine/Unit/Segments/SegmentEvaluatorTest.php
+++ b/tests/Engine/Unit/Segments/SegmentEvaluatorTest.php
@@ -221,7 +221,7 @@ class SegmentEvaluatorTest extends TestCase
     {
         $percentageSplitCondition = (new SegmentConditionModel())
             ->withOperator(SegmentConditions::PERCENTAGE_SPLIT)
-            ->withValue("10");
+            ->withValue('10');
 
         $segmentRule = (new SegmentRuleModel())
             ->withType(SegmentRules::ALL_RULE)
@@ -256,6 +256,6 @@ class SegmentEvaluatorTest extends TestCase
 
         $result = SegmentEvaluator::evaluateIdentityInSegment($identityModel, $segmentModel);
 
-        $this->assertEquals($result, True);
+        $this->assertEquals($result, true);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith/issues/2186 for PHP client. MUST be released as part of a new major version. 