### PR TITLE
Fix local evaluation when values are null

### DIFF
--- a/src/Concerns/JsonSerializer.php
+++ b/src/Concerns/JsonSerializer.php
@@ -23,16 +23,18 @@ trait JsonSerializer
      */
     protected function setValues($values)
     {
-        foreach ($values as $key => $value) {
-            if (isset($this->keys[$key])) {
-                $className = $this->keys[$key];
-                if (method_exists($className, 'build')) {
-                    $this->{ $key } = $className::build($value);
+        if (is_array($values) || is_object($values)) {
+            foreach ($values as $key => $value) {
+                if (isset($this->keys[$key])) {
+                    $className = $this->keys[$key];
+                    if (method_exists($className, 'build')) {
+                        $this->{$key} = $className::build($value);
+                    } else {
+                        $this->{$key} = new $className($value);
+                    }
                 } else {
-                    $this->{ $key} = new $className($value);
+                    $this->{$key} = $value;
                 }
-            } else {
-                $this->{ $key } = $value;
             }
         }
     }


### PR DESCRIPTION
When using local evaluation we encounter the following error:

vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php:26
```
Warning: foreach() argument must be of type array|object, null given
```