### PR TITLE
Avoid deprecation about dynamic properties

### DIFF
--- a/src/Engine/Environments/EnvironmentAPIKeyModel.php
+++ b/src/Engine/Environments/EnvironmentAPIKeyModel.php
@@ -6,6 +6,7 @@ use DateTime;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class EnvironmentAPIKeyModel
 {
     use HasWith;

--- a/src/Engine/Environments/EnvironmentModel.php
+++ b/src/Engine/Environments/EnvironmentModel.php
@@ -8,6 +8,7 @@ use Flagsmith\Engine\Environments\Integrations\IntegrationModel;
 use Flagsmith\Engine\Projects\ProjectModel;
 use Flagsmith\Engine\Utils\Collections\FeatureStateModelList;
 
+#[\AllowDynamicProperties]
 class EnvironmentModel
 {
     use HasWith;

--- a/src/Engine/Environments/Integrations/IntegrationModel.php
+++ b/src/Engine/Environments/Integrations/IntegrationModel.php
@@ -5,6 +5,7 @@ namespace Flagsmith\Engine\Environments\Integrations;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class IntegrationModel
 {
     use HasWith;

--- a/src/Engine/Features/FeatureModel.php
+++ b/src/Engine/Features/FeatureModel.php
@@ -5,6 +5,7 @@ namespace Flagsmith\Engine\Features;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class FeatureModel
 {
     use HasWith;

--- a/src/Engine/Features/FeatureSegmentModel.php
+++ b/src/Engine/Features/FeatureSegmentModel.php
@@ -5,6 +5,7 @@ namespace Flagsmith\Engine\Features;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class FeatureSegmentModel
 {
     use HasWith;

--- a/src/Engine/Features/FeatureStateModel.php
+++ b/src/Engine/Features/FeatureStateModel.php
@@ -8,6 +8,7 @@ use Flagsmith\Engine\Utils\Collections\MultivariateFeatureStateValueModelList;
 use Flagsmith\Engine\Utils\HashingTrait;
 use Flagsmith\Engine\Utils\UniqueUID;
 
+#[\AllowDynamicProperties]
 class FeatureStateModel
 {
     use HasWith, HashingTrait, JsonSerializer {

--- a/src/Engine/Features/MultivariateFeatureOptionModel.php
+++ b/src/Engine/Features/MultivariateFeatureOptionModel.php
@@ -5,6 +5,7 @@ namespace Flagsmith\Engine\Features;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class MultivariateFeatureOptionModel
 {
     use HasWith;

--- a/src/Engine/Features/MultivariateFeatureStateValueModel.php
+++ b/src/Engine/Features/MultivariateFeatureStateValueModel.php
@@ -6,6 +6,7 @@ use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 use Flagsmith\Engine\Utils\UniqueUID;
 
+#[\AllowDynamicProperties]
 class MultivariateFeatureStateValueModel
 {
     use HasWith;

--- a/src/Engine/Identities/IdentityModel.php
+++ b/src/Engine/Identities/IdentityModel.php
@@ -9,6 +9,7 @@ use Flagsmith\Engine\Utils\Collections\IdentityFeaturesList;
 use Flagsmith\Engine\Utils\Collections\IdentityTraitList;
 use Flagsmith\Engine\Utils\UniqueUID;
 
+#[\AllowDynamicProperties]
 class IdentityModel
 {
     use HasWith;

--- a/src/Engine/Identities/Traits/TraitModel.php
+++ b/src/Engine/Identities/Traits/TraitModel.php
@@ -5,6 +5,7 @@ namespace Flagsmith\Engine\Identities\Traits;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class TraitModel
 {
     use HasWith;

--- a/src/Engine/Organisations/OrganisationModel.php
+++ b/src/Engine/Organisations/OrganisationModel.php
@@ -5,6 +5,7 @@ namespace Flagsmith\Engine\Organisations;
 use Flagsmith\Concerns\HasWith;
 use Flagsmith\Concerns\JsonSerializer;
 
+#[\AllowDynamicProperties]
 class OrganisationModel
 {
     use HasWith;

--- a/src/Engine/Projects/ProjectModel.php
+++ b/src/Engine/Projects/ProjectModel.php
@@ -7,6 +7,7 @@ use Flagsmith\Concerns\JsonSerializer;
 use Flagsmith\Engine\Organisations\OrganisationModel;
 use Flagsmith\Engine\Utils\Collections\SegmentModelList;
 
+#[\AllowDynamicProperties]
 class ProjectModel
 {
     use HasWith;

--- a/src/Engine/Segments/SegmentConditionModel.php
+++ b/src/Engine/Segments/SegmentConditionModel.php
@@ -7,6 +7,7 @@ use Flagsmith\Concerns\JsonSerializer;
 use Flagsmith\Engine\Segments\SegmentConditions;
 use Flagsmith\Engine\Utils\Semver;
 
+#[\AllowDynamicProperties]
 class SegmentConditionModel
 {
     use HasWith;

--- a/src/Engine/Segments/SegmentConditionModel.php
+++ b/src/Engine/Segments/SegmentConditionModel.php
@@ -115,7 +115,7 @@ class SegmentConditionModel
                 $condition = $traitValue <= $castedValue;
                 break;
             case (SegmentConditions::NOT_EQUAL):
-                $condition = $traitValue !=$castedValue;
+                $condition = $traitValue != $castedValue;
                 break;
             case (SegmentConditions::CONTAINS):
                 $condition = strpos($traitValue, (string) $castedValue) !== false;

--- a/src/Engine/Segments/SegmentModel.php
+++ b/src/Engine/Segments/SegmentModel.php
@@ -7,6 +7,7 @@ use Flagsmith\Concerns\JsonSerializer;
 use Flagsmith\Engine\Utils\Collections\FeatureStateModelList;
 use Flagsmith\Engine\Utils\Collections\SegmentRuleModelList;
 
+#[\AllowDynamicProperties]
 class SegmentModel
 {
     use HasWith;

--- a/src/Engine/Segments/SegmentRuleModel.php
+++ b/src/Engine/Segments/SegmentRuleModel.php
@@ -7,6 +7,7 @@ use Flagsmith\Concerns\JsonSerializer;
 use Flagsmith\Engine\Utils\Collections\SegmentConditionModelList;
 use Flagsmith\Engine\Utils\Collections\SegmentRuleModelList;
 
+#[\AllowDynamicProperties]
 class SegmentRuleModel
 {
     use HasWith;

--- a/src/Models/Flags.php
+++ b/src/Models/Flags.php
@@ -91,7 +91,7 @@ class Flags
         FeatureStateModelList $featureStateModelsList,
         ?AnalyticsProcessor $analyticsProcessor,
         ?\Closure $defaultFlagHandler,
-        $identityId =null
+        $identityId = null
     ) {
         $flags = [];
         foreach ($featureStateModelsList->getArrayCopy() as $featureState) {
@@ -116,7 +116,7 @@ class Flags
         object $apiFlags,
         ?AnalyticsProcessor $analyticsProcessor,
         ?\Closure $defaultFlagHandler,
-        $identityId =null
+        $identityId = null
     ) {
         $flags = [];
         foreach ($apiFlags as $apiFlag) {


### PR DESCRIPTION
Hi @matthewelwell @dabeeeenster

I'm getting a lot of deprecation when using this tool like
```
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Projects\ProjectModel::$enable_realtime_updates is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Projects\ProjectModel::$server_key_only_feature_ids is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$name is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$allow_client_traits is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$updated_at is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$hide_sensitive_data is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$hide_disabled_flags is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$use_identity_composite_key_for_hashing is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$dynatrace_config is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$rudderstack_config is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
PHP Deprecated:  Creation of dynamic property Flagsmith\Engine\Environments\EnvironmentModel::$webhook_config is deprecated in /var/www/wg-app/vendor/flagsmith/flagsmith-php-client/src/Concerns/JsonSerializer.php on line 38
```
And there is a lot more.

This is because a lot of data sent by the api is not handled (and maybe not needed to be handled) by the JsonSerializer.

A way to avoid such deprecations is to use the 
```
#[\AllowDynamicProperties]
```
attribute.