### PR TITLE
(feat): Add back withUseCacheAsFailover

### DIFF
--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -255,6 +255,18 @@ class Flagsmith
     }
 
     /**
+     * Whether to use the Cache as a failover for server errors
+     *
+     * @param bool $useCacheAsFailover
+     *
+     * @return self
+     */
+    public function withUseCacheAsFailover(bool $useCacheAsFailover): self
+    {
+        return $this->with('useCacheAsFailover', $useCacheAsFailover);
+    }
+
+    /**
      * Get the environment model.
      * @return EnvironmentModel
      */


### PR DESCRIPTION
At some point in the past withUseCacheAsFailover was removed but the property itself still exists in the class and it's referenced in the cache call so it should be settable.