### PR TITLE
Fix method getEnvironment return type

### DIFF
--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -256,9 +256,9 @@ class Flagsmith
 
     /**
      * Get the environment model.
-     * @return EnvironmentModel
+     * @return EnvironmentModel|null
      */
-    public function getEnvironment(): EnvironmentModel
+    public function getEnvironment(): ?EnvironmentModel
     {
         return $this->environment;
     }


### PR DESCRIPTION
Method getEnvironment can potentially return a null value