### PR TITLE
Flagsmith instance clonning

### DIFF
--- a/src/Concerns/HasWith.php
+++ b/src/Concerns/HasWith.php
@@ -5,7 +5,7 @@ namespace Flagsmith\Concerns;
 trait HasWith
 {
     /**
-     * Clones class with new property
+     * Set the new property
      *
      * @param string $property
      * @param mixed $value
@@ -13,8 +13,7 @@ trait HasWith
      */
     protected function with(string $property, $value): self
     {
-        $self = clone $this;
-        $self->{$property} = $value;
-        return $self;
+        $this->{$property} = $value;
+        return $this;
     }
 }


### PR DESCRIPTION
Hi, 
clonning the instance with every configuration change is very expensive and not necessary in context of this library, I propose just setting the property and returning original object.

This also fixes Flagsmith.php line 183

```
    public function withCache(?CacheInterface $cache): self
    {
        if (is_null($cache)) {
            $this->with('cache', null); <-- result of this expression is not used anywhere (someone probably missed the clonning)
        }

        return $this->with(
            'cache',
            new Cache($cache, $this->cachePrefix, $this->timeToLive)
        );
    }
```