### PR TITLE
Add ext- requirements to composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The Flagsmith PHP SDK requires the following PHP extensions to be enabled. These
 
 - bc-math
 - gmp
-- json
 
 Please view the documentation here to install the extensions, if you haven't already. For [BC-Math](https://www.php.net/manual/en/bc.installation.php) and [GMP](https://www.php.net/manual/en/gmp.installation.php).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The Flagsmith PHP SDK requires the following PHP extensions to be enabled. These
 
 - bc-math
 - gmp
+- json
 
 Please view the documentation here to install the extensions, if you haven't already. For [BC-Math](https://www.php.net/manual/en/bc.installation.php) and [GMP](https://www.php.net/manual/en/gmp.installation.php).
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=7.4",
         "ext-bcmath": "*",
         "ext-gmp": "*",
+        "ext-json": "*",
         "php-http/discovery": "^1.14",
         "psr/simple-cache": ">=1.0",
         "psr/http-factory-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
     ],
     "require": {
         "php": ">=7.4",
+        "ext-bcmath": "*",
+        "ext-gmp": "*",
         "php-http/discovery": "^1.14",
         "psr/simple-cache": ">=1.0",
         "psr/http-factory-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "php": ">=7.4",
         "ext-bcmath": "*",
         "ext-gmp": "*",
-        "ext-json": "*",
         "php-http/discovery": "^1.14",
         "psr/simple-cache": ">=1.0",
         "psr/http-factory-implementation": "1.0",


### PR DESCRIPTION
Having extensions listed in documentation is cool, having them in composer is even cooler. Added bcmath, gmp, json to composer.json.