### PR TITLE
ci: stop testing against <8.1

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        php-version: ["7.4", "8.0", "8.1", "8.2"]
+        php-version: ["8.1", "8.2", "8.3"]
 
     steps:
       - name: Cloning repo


### PR DESCRIPTION
PHP 7.4 and 8.0 are EOL, this removes them from the test matrix. 

See [here](https://www.php.net/supported-versions.php) for reference. 