### PR TITLE
deps: drop support for php<8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "flagsmith/flagsmith-php-client",
     "type": "library",
-    "version": "v4.3.1",
+    "version": "v4.4.0",
     "license": "BSD-3-Clause",
     "authors": [
         {
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "php-http/discovery": "^1.14",
         "psr/simple-cache": ">=1.0",
         "psr/http-factory-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "flagsmith/flagsmith-php-client",
     "type": "library",
-    "version": "v4.4.0",
+    "version": "v4.3.1",
     "license": "BSD-3-Clause",
     "authors": [
         {


### PR DESCRIPTION
Drop support for PHP<8.1 since they are no longer supported versions. See [here](https://www.php.net/supported-versions.php) for context.