### PR TITLE
Add ext-json as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">=8.1",
+        "ext-json": "*",
         "php-http/discovery": "^1.14",
         "psr/simple-cache": ">=1.0",
         "psr/http-factory-implementation": "1.0",


### PR DESCRIPTION
Hi @matthewelwell

`\JsonSerializable` is used and `json_` methods too, so it should be a requirement in the composer.json.