### PR TITLE
Fix nullable parameter

### DIFF
--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -63,7 +63,7 @@ class Engine
     public static function getIdentityFeatureStates(
         EnvironmentModel $environment,
         IdentityModel $identity,
-        array $overrideTraits = null
+        ?array $overrideTraits = null
     ): array {
         $featureStates = self::_getIdentityFeatureStatesDict(
             $environment,
@@ -96,7 +96,7 @@ class Engine
         EnvironmentModel $environment,
         IdentityModel $identity,
         string $featureName,
-        array $overrideTraits = null
+        ?array $overrideTraits = null
     ): FeatureStateModel {
         $featureStates = self::_getIdentityFeatureStatesDict(
             $environment,
@@ -128,7 +128,7 @@ class Engine
     private static function _getIdentityFeatureStatesDict(
         EnvironmentModel $environment,
         IdentityModel $identity,
-        array $overrideTraits = null
+        ?array $overrideTraits = null
     ): array {
         $featureStates = [];
         foreach ($environment->getFeatureStates() as $fs) {

--- a/src/Engine/Segments/SegmentEvaluator.php
+++ b/src/Engine/Segments/SegmentEvaluator.php
@@ -20,7 +20,7 @@ class SegmentEvaluator
     public static function getIdentitySegments(
         EnvironmentModel $environment,
         IdentityModel $identity,
-        array $overrideTraits = null
+        ?array $overrideTraits = null
     ): array {
         return array_filter(
             $environment->getProject()->getSegments()->getArrayCopy(),
@@ -42,7 +42,7 @@ class SegmentEvaluator
     public static function evaluateIdentityInSegment(
         IdentityModel $identity,
         SegmentModel $segment,
-        array $overrideTraits = null
+        ?array $overrideTraits = null
     ): bool {
         $rulesCount = count($segment->getRules());
         $identityId = ($identity->getDjangoId() != null) ? $identity->getDjangoId() : $identity->compositeKey();

--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -60,15 +60,15 @@ class Flagsmith
      * @throws ValueError
      */
     public function __construct(
-        string $apiKey = null,
-        string $host = null,
-        object $customHeaders = null,
-        int $environmentTtl = null,
-        Retry $retries = null,
+        ?string $apiKey = null,
+        ?string $host = null,
+        ?object $customHeaders = null,
+        ?int $environmentTtl = null,
+        ?Retry $retries = null,
         bool $enableAnalytics = false,
-        \Closure $defaultFlagHandler = null,
+        ?\Closure $defaultFlagHandler = null,
         bool $offlineMode = false,
-        IOfflineHandler $offlineHandler = null
+        ?IOfflineHandler $offlineHandler = null
     ) {
         if ($offlineMode and is_null($offlineHandler)) {
             throw new ValueError('offlineHandler must be provided to use offline mode.');

--- a/src/Utils/AnalyticsProcessor.php
+++ b/src/Utils/AnalyticsProcessor.php
@@ -31,9 +31,9 @@ class AnalyticsProcessor
         string $environmentKey,
         string $baseApiUrl,
         int $timeout = 5,
-        ClientInterface $client = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null
+        ?ClientInterface $client = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null
     ) {
         $this->analytics_endpoint = rtrim($baseApiUrl, '/') . self::ANALYTICS_ENDPOINT;
         $this->environment_key = $environmentKey;


### PR DESCRIPTION
Hi @matthewelwell 

With PHP 8.4 we get deprecation like
```
Flagsmith\Flagsmith::__construct(): Implicitly marking parameters $apiKey, $host, $customHeaders, $environmentTtl, $retries, $defaultFlagHandler, and $offlineHandler as nullable is deprecated, the explicit nullable type must be used instead.
```

I try to solve all of them.