### PR TITLE
fix: Fix generateIdentitiesCacheKey

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/src/Utils/IdentitiesGenerator.php
+++ b/src/Utils/IdentitiesGenerator.php
@@ -37,6 +37,6 @@ class IdentitiesGenerator
     {
         $hashedTraits = $traits !== null ? '.'.sha1(serialize($traits)) : '';
         $hashedIdentifier = sha1($identifier);
-        return 'Identity.'.$transient ? 'Transient' : ''.$hashedIdentifier.$hashedTraits;
+        return 'Identity.'.($transient ? 'Transient' : '').$hashedIdentifier.$hashedTraits;
     }
 }

--- a/tests/Engine/Unit/Utils/IdentitiesGeneratorTest.php
+++ b/tests/Engine/Unit/Utils/IdentitiesGeneratorTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Engine\Unit\Utils;
+
+use Flagsmith\Utils\IdentitiesGenerator;
+use PHPUnit\Framework\TestCase;
+
+class IdentitiesGeneratorTest extends TestCase
+{
+
+    public function testGenerateIdentitiesCacheKey(): void
+    {
+        $identityId = 'test-identity-id';
+        $traits = (object) ['key' => 'value'];
+        $cacheKey = IdentitiesGenerator::generateIdentitiesCacheKey($identityId, $traits, null);
+
+        $this->assertStringContainsString('Identity.', $cacheKey);
+        $this->assertStringContainsString(sha1($identityId), $cacheKey);
+    }
+
+    public function testGenerateIdentitiesTransientCacheKey(): void
+    {
+        $identityId = 'test-identity-id';
+        $traits = (object) ['key' => 'value'];
+        $cacheKey = IdentitiesGenerator::generateIdentitiesCacheKey($identityId, $traits, true);
+
+        $this->assertStringContainsString('Identity.Transient', $cacheKey);
+        $this->assertStringContainsString(sha1($identityId), $cacheKey);
+    }
+}

--- a/tests/Engine/Unit/Utils/IdentitiesGeneratorTest.php
+++ b/tests/Engine/Unit/Utils/IdentitiesGeneratorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Engine\Unit\Utils;
 
@@ -7,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class IdentitiesGeneratorTest extends TestCase
 {
-
     public function testGenerateIdentitiesCacheKey(): void
     {
         $identityId = 'test-identity-id';


### PR DESCRIPTION
Fix [#89](https://github.com/Flagsmith/flagsmith-php-client/issues/89)