### PR TITLE
feat: get-version-from-composer-and-pass-it-in-headers

### DIFF
--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -19,6 +19,7 @@ use Flagsmith\Offline\IOfflineHandler;
 use Flagsmith\Utils\AnalyticsProcessor;
 use Flagsmith\Utils\IdentitiesGenerator;
 use Flagsmith\Utils\Retry;
+use Flagsmith\Utils\UserAgent;
 use JsonException;
 use ValueError;
 use Psr\Http\Client\ClientInterface;
@@ -596,7 +597,8 @@ class Flagsmith
             ->createRequest($method, rtrim($this->host, '/') . '/' . $uri)
             ->withHeader('Accept', 'application/json')
             ->withHeader('Content-Type', 'application/json')
-            ->withHeader('X-Environment-Key', $this->apiKey);
+            ->withHeader('X-Environment-Key', $this->apiKey)
+            ->withHeader('User-Agent', UserAgent::get());
 
         if (!empty($this->customHeaders)) {
             foreach ($this->customHeaders as $name => $value) {

--- a/src/Utils/AnalyticsProcessor.php
+++ b/src/Utils/AnalyticsProcessor.php
@@ -67,6 +67,7 @@ class AnalyticsProcessor
             ->withHeader('Accept', 'application/json')
             ->withHeader('Content-Type', 'application/json')
             ->withHeader('X-Environment-Key', $this->environment_key)
+            ->withHeader('User-Agent', UserAgent::get())
             ->withBody($stream);
 
         try {

--- a/src/Utils/UserAgent.php
+++ b/src/Utils/UserAgent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Flagsmith\Utils;
+
+/**
+ * UserAgent utility class for generating SDK user agent strings.
+ */
+class UserAgent
+{
+    /**
+     * Get the user agent string for the SDK.
+     *
+     * @return string The user agent string in the format "flagsmith-php-sdk/{version}"
+     */
+    public static function get(): string
+    {
+        try {
+            $composerPath = __DIR__ . '/../../composer.json';
+            $content = file_get_contents($composerPath);
+            $data = json_decode($content, true);
+            $version = $data['version'] ?? null;
+
+            if ($version) {
+                return "flagsmith-php-sdk/{$version}";
+            }
+        } catch (\Exception $e) {
+            // Silently fall through to default
+        }
+
+        return 'flagsmith-php-sdk/unknown';
+    }
+}

--- a/tests/FlagsmithClientTest.php
+++ b/tests/FlagsmithClientTest.php
@@ -7,6 +7,7 @@ use FlagsmithTest\ClientFixtures;
 use FlagsmithTest\Offline\FakeOfflineHandler;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 class FlagsmithClientTest extends TestCase
@@ -440,5 +441,33 @@ class FlagsmithClientTest extends TestCase
 
         $this->assertEquals($identityFlags->getFlag('some_feature')->enabled, true);
         $this->assertEquals($identityFlags->getFlag('some_feature')->value, 'some-value');
+    }
+
+    public function testApiRequestsIncludeUserAgentHeader()
+    {
+        $capturedRequest = null;
+        $mockClient = $this->createMock(ClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function ($request) use (&$capturedRequest) {
+                $capturedRequest = $request;
+                return true;
+            }))
+            ->willReturn(
+                new Response(200, ['Content-Type' => 'application/json'], file_get_contents(__DIR__ . '/Data/flags.json'))
+            );
+
+        $flagsmith = (new Flagsmith('api_key'))
+            ->withClient($mockClient);
+
+        $flagsmith->getEnvironmentFlags();
+
+        $this->assertNotNull($capturedRequest);
+        $this->assertTrue($capturedRequest->hasHeader('User-Agent'));
+        $userAgent = $capturedRequest->getHeaderLine('User-Agent');
+        $composerData = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+        $expectedVersion = $composerData['version'] ?? 'unknown';
+        $expectedUserAgent = "flagsmith-php-sdk/{$expectedVersion}";
+        $this->assertEquals($expectedUserAgent, $userAgent);
     }
 }

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Flagsmith\Utils\UserAgent;
+
+class UserAgentTest extends TestCase
+{
+    public function testGetUserAgentReturnsVersionFromComposerJson()
+    {
+        $userAgent = UserAgent::get();
+
+        $composerPath = __DIR__ . '/../composer.json';
+        $composerData = json_decode(file_get_contents($composerPath), true);
+        $expectedVersion = $composerData['version'] ?? 'unknown';
+
+        $this->assertEquals("flagsmith-php-sdk/{$expectedVersion}", $userAgent);
+    }
+}


### PR DESCRIPTION
Contributes to #107.

---

Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
-  new utility `getUserAgent` to get version from composer as `flagsmith-php-sdk/v4.5.1` or returns `flagsmith-php-sdk/unknown`
- Added header in API and Analytics requests

## How did you test this code?
- Added tests

Use this dummy php server:
```
<?php

require_once __DIR__ . '/vendor/autoload.php';

use Flagsmith\Flagsmith;
use Psr\Http\Client\ClientInterface;
use Psr\Http\Message\RequestInterface;
use Psr\Http\Message\ResponseInterface;
use GuzzleHttp\Psr7\Response;

class LoggingClient implements ClientInterface
{
    public function sendRequest(RequestInterface $request): ResponseInterface
    {
        echo "\n=== HTTP REQUEST ===\n";
        echo "Method: " . $request->getMethod() . "\n";
        echo "URI: " . $request->getUri() . "\n";
        echo "\nHeaders:\n";
        foreach ($request->getHeaders() as $name => $values) {
            foreach ($values as $value) {
                echo "  {$name}: {$value}\n";
            }
        }
        return new Response(200, ['Content-Type' => 'application/json'], []);
    }
}


try {
    $flagsmith = (new Flagsmith('test-api-key'))
        ->withClient(new LoggingClient());

    echo "Getting environment flags...\n";
    $flags = $flagsmith->getEnvironmentFlags();
} catch (Exception $e) {
    echo "\n✗ Error: " . "\n";
}
```

This returns normally:

```
 Method: GET
URI: https://edge.api.flagsmith.com/api/v1/flags/

Headers:
  Host: edge.api.flagsmith.com
  Accept: application/json
  Content-Type: application/json
  X-Environment-Key: test-api-key
  User-Agent: flagsmith-php-sdk/v4.5.1
```

Or after removing the version in composer:
```
 Method: GET
URI: https://edge.api.flagsmith.com/api/v1/flags/

Headers:
  Host: edge.api.flagsmith.com
  Accept: application/json
  Content-Type: application/json
  X-Environment-Key: test-api-key
  User-Agent: flagsmith-php-sdk/unknown
```