### PR TITLE
fix(Local Evaluation): Omit segments from environment flags evaluation

### DIFF
--- a/src/Flagsmith.php
+++ b/src/Flagsmith.php
@@ -417,7 +417,11 @@ class Flagsmith
             throw new FlagsmithClientError('Evaluation context is not present');
         }
 
-        $evaluationResult = Engine::getEvaluationResult($this->localEvaluationContext);
+        // Omit segments from evaluation context for environment flags
+        $context = $this->localEvaluationContext->deepClone();
+        $context->segments = [];
+
+        $evaluationResult = Engine::getEvaluationResult($context);
 
         return Flags::fromEvaluationResult(
             $evaluationResult,

--- a/tests/ClientFixtures.php
+++ b/tests/ClientFixtures.php
@@ -99,4 +99,18 @@ class ClientFixtures
     {
         return EnvironmentModel::build(json_decode(self::loadFileContents('environment.json')));
     }
+
+    public static function getMockClientWithSegmentOverride()
+    {
+        $handlerBuilder = self::getHandlerBuilder();
+        $handlerBuilder->addRoute(
+            self::getRouteBuilder()->new()
+                ->withMethod('GET')
+                ->withPath('/api/v1/environment-document/')
+                ->withFileResponse(self::DATA_DIR . 'environment_with_segment_override.json')
+                ->build()
+        );
+
+        return self::getMockClient($handlerBuilder, false);
+    }
 }

--- a/tests/Data/environment_with_segment_override.json
+++ b/tests/Data/environment_with_segment_override.json
@@ -1,0 +1,70 @@
+{
+  "api_key": "test-api-key",
+  "name": "Test environment with segment override",
+  "project": {
+    "name": "Test project",
+    "organisation": {
+      "feature_analytics": false,
+      "name": "Test Org",
+      "id": 1,
+      "persist_trait_data": true,
+      "stop_serving_flags": false
+    },
+    "id": 1,
+    "hide_disabled_flags": false,
+    "segments": [
+      {
+        "id": 1,
+        "name": "Test segment with override",
+        "feature_states": [
+          {
+            "feature_state_value": "segment-override-value",
+            "django_id": 10,
+            "featurestate_uuid": "99999999-9999-9999-9999-999999999999",
+            "feature": {
+              "name": "test_feature",
+              "type": "STANDARD",
+              "id": 10
+            },
+            "enabled": false,
+            "multivariate_feature_state_values": [],
+            "feature_segment": {
+              "priority": 1
+            }
+          }
+        ],
+        "rules": [
+          {
+            "type": "ALL",
+            "rules": [],
+            "conditions": [
+              {
+                "operator": "EQUAL",
+                "property_": "$.environment.name",
+                "value": "Test environment with segment override"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "segment_overrides": [],
+  "id": 1,
+  "feature_states": [
+    {
+      "feature_state_value": "environment-default-value",
+      "django_id": 1,
+      "featurestate_uuid": "00000000-0000-0000-0000-000000000000",
+      "feature": {
+        "name": "test_feature",
+        "type": "STANDARD",
+        "id": 10
+      },
+      "segment_id": null,
+      "enabled": true,
+      "multivariate_feature_state_values": []
+    }
+  ],
+  "identity_overrides": []
+}

--- a/tests/FlagsmithClientTest.php
+++ b/tests/FlagsmithClientTest.php
@@ -478,4 +478,25 @@ class FlagsmithClientTest extends TestCase
         $expectedUserAgent = "flagsmith-php-sdk/{$expectedVersion}";
         $this->assertEquals($expectedUserAgent, $userAgent);
     }
+
+    public function testGetEnvironmentFlagsOmitsSegmentsFromEvaluation()
+    {
+        // Given
+        $flagsmith = (new Flagsmith('ser.api_key', environmentTtl: 1))
+            ->withClient(ClientFixtures::getMockClientWithSegmentOverride());
+        $flagsmith->updateEnvironment();
+
+        // When
+        $environmentFlags = $flagsmith->getEnvironmentFlags();
+        $identityFlags = $flagsmith->getIdentityFlags('test-identity');
+
+        // Then
+        $environmentFlag = $environmentFlags->getFlag('test_feature');
+        $this->assertTrue($environmentFlag->enabled);
+        $this->assertEquals('environment-default-value', $environmentFlag->value);
+
+        $identityFlag = $identityFlags->getFlag('test_feature');
+        $this->assertFalse($identityFlag->enabled);
+        $this->assertEquals('segment-override-value', $identityFlag->value);
+    }
 }


### PR DESCRIPTION
Environment flags return only environment defaults, excluding segment-based targeting.

See https://github.com/Flagsmith/flagsmith/issues/6051.

## Changes
- [x] Modify `getEnvironmentFlagsFromLocalEvaluationContext()` to omit segments from evaluation context
- [x] Add test verifying environment flags ignore segments while identity flags respect them
- [x] Add test fixture with segment matching environment-level context

Closes #116

Review effort: 1/5