### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/Engine/EngineTests/EngineTestData"]
 	path = tests/Engine/EngineTests/EngineTestData
 	url = git@github.com:Flagsmith/engine-test-data.git
-	tag = v3.5.0
+	tag = v3.7.0

--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -219,19 +219,40 @@ class Engine
             }
         }
 
-        if ($rule->type === SegmentRuleType::ANY && !$any) {
+        if ($rule->type === SegmentRuleType::ANY && !$any && !empty($rule->conditions)) {
             return false;
         }
 
+        $anySubRule = false;
         foreach ($rule->rules as $subRule) {
-            $ruleMatches = self::_contextMatchesRule(
+            $subRuleMatches = self::_contextMatchesRule(
                 $context,
                 $subRule,
                 $segmentKey,
             );
-            if (!$ruleMatches) {
-                return false;
+
+            switch ($rule->type) {
+                case SegmentRuleType::ALL:
+                    if (!$subRuleMatches) {
+                        return false;
+                    }
+                    break;
+                case SegmentRuleType::NONE:
+                    if ($subRuleMatches) {
+                        return false;
+                    }
+                    break;
+                case SegmentRuleType::ANY:
+                    if ($subRuleMatches) {
+                        $anySubRule = true;
+                        break 2;
+                    }
+                    break;
             }
+        }
+
+        if ($rule->type === SegmentRuleType::ANY && !$anySubRule && !empty($rule->rules)) {
+            return false;
         }
 
         return true;


### PR DESCRIPTION
## Summary
- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation: sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL logic
- Fixed premature false return for ANY rules with no conditions but with sub-rules, which prevented sub-rule evaluation entirely

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## Test plan
- [x] Bumped engine-test-data to v3.7.0 (includes new sub-rule type test cases)
- [x] Verified tests fail before the fix (2 failures)
- [x] Applied the fix
- [x] Verified all 270 tests pass after the fix (921 assertions)