### PR TITLE
chore: Add composer.phar to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 .php-cs-fixer.php export-ignore
 .prettierrc export-ignore
 tests export-ignore
+composer.phar export-ignore


### PR DESCRIPTION
Hi, @matthewelwell @khvn26

This is a follow up of https://github.com/Flagsmith/flagsmith-php-client/pull/38

Currently installing this lib also install the composer phar, which is not needed.

This is the PR which added the composer phar 
https://github.com/Flagsmith/flagsmith-php-client/pull/115